### PR TITLE
#34/infra/language service

### DIFF
--- a/Iteracode.Api/Abstractions/ILanguageService.cs
+++ b/Iteracode.Api/Abstractions/ILanguageService.cs
@@ -1,0 +1,6 @@
+namespace Iteracode.Api.Abstractions;
+
+public interface ILanguageService
+{
+    int GetJudge0IdForLanguage(string language);
+}

--- a/Iteracode.Api/Data/ApplicationDbContext.cs
+++ b/Iteracode.Api/Data/ApplicationDbContext.cs
@@ -12,4 +12,62 @@ public class ApplicationDbContext : IdentityDbContext<User>
 
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
     public DbSet<BlacklistedToken> BlacklistedTokens => Set<BlacklistedToken>();
+    public DbSet<Problem> Problems => Set<Problem>();
+    public DbSet<ProblemLanguage> ProblemLanguages => Set<ProblemLanguage>();
+    public DbSet<Testcase> TestCases => Set<Testcase>();
+    public DbSet<ProblemTestcase> ProblemTestCases => Set<ProblemTestcase>();
+    public DbSet<LanguageJudge0Id> LanguageJudge0Ids => Set<LanguageJudge0Id>();
+    public DbSet<RunnerTemplate> RunnerTemplates => Set<RunnerTemplate>();
+
+    // protected override void OnModelCreating(ModelBuilder builder)
+    // {
+    //     base.OnModelCreating(builder);
+        
+    //     // ProblemTestCase has a composite key of ProblemId and TestCaseId
+    //     builder.Entity<ProblemTestCase>()
+    //         .HasKey(ptc => new { ptc.ProblemId, ptc.TestCaseId });
+
+    //     // Configure the relationship between ProblemTestCase and Problem
+    //     builder.Entity<ProblemTestCase>()
+    //         .HasOne(ptc => ptc.Problem)
+    //         .WithMany(p => p.ProblemTestCases)
+    //         .HasForeignKey(ptc => ptc.ProblemId)
+    //         .OnDelete(DeleteBehavior.Cascade); // Delete ProblemTestCase when Problem is deleted
+
+    //     // Configure the relationship between ProblemTestCase and TestCase
+    //     builder.Entity<ProblemTestCase>()
+    //         .HasOne(ptc => ptc.TestCase)
+    //         .WithMany(tc => tc.ProblemTestCases)
+    //         .HasForeignKey(ptc => ptc.TestCaseId)
+    //         .OnDelete(DeleteBehavior.Restrict); // Don't delete TestCase when ProblemTestCase is deleted
+
+    //     // Configure the relationship between ProblemImpl and Problem
+    //     builder.Entity<ProblemImpl>()
+    //         .HasOne(pi => pi.Problem)
+    //         .WithMany(p => p.Implementations)
+    //         .HasForeignKey(pi => pi.ProblemId)
+    //         .OnDelete(DeleteBehavior.Cascade); // Delete ProblemImpl when Problem is deleted
+
+    //     // Ensure that each Problem can only have one implementation per language
+    //     builder.Entity<ProblemImpl>()
+    //         .HasIndex(pi => new { pi.ProblemId, pi.LanguageId})
+    //         .IsUnique();
+
+    //     builder.Entity<Submission>()
+    //         .HasOne(s => s.User)
+    //         .WithMany()
+    //         .HasForeignKey(s => s.UserId)
+    //         .OnDelete(DeleteBehavior.Cascade); // Delete Submission when User is deleted
+
+    //     builder.Entity<Submission>()
+    //         .HasOne(s => s.Problem)
+    //         .WithMany(p => p.Submissions)
+    //         .HasForeignKey(s => s.ProblemId)
+    //         .OnDelete(DeleteBehavior.SetNull) // Set ProblemId to null when Problem is deleted
+    //         .IsRequired(false);
+
+    //     builder.Entity<Submission>()
+    //         .Property(s => s.Result)
+    //         .HasConversion<string>(); // Store enum as string in the database
+    // }
 }

--- a/Iteracode.Api/Models/LanguageJudge0Id.cs
+++ b/Iteracode.Api/Models/LanguageJudge0Id.cs
@@ -1,0 +1,10 @@
+namespace Iteracode.Api.Models;
+
+public class LanguageJudge0Id
+{
+	public int Id { get; set;}
+	public string Language { get; set; } = null!; // e.g., "python", "c", "cpp"
+	public int Judge0Id { get; set; }
+	public bool Enabled { get; set; }
+	public DateTimeOffset CreatedAt { get; set; }
+}

--- a/Iteracode.Api/Services/LanguageService.cs
+++ b/Iteracode.Api/Services/LanguageService.cs
@@ -1,0 +1,21 @@
+using Iteracode.Api.Abstractions;
+using Iteracode.Api.Data;
+
+namespace Iteracode.Api.Services;
+
+public class LanguageService : ILanguageService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly Dictionary<string, int> _languageIds;
+
+    public LanguageService(ApplicationDbContext context)
+    {
+        _context = context;
+        _languageIds = _context.LanguageJudge0Ids
+            .Where(l => l.Enabled)
+            .ToDictionary(l => l.Language, l => l.Judge0Id);
+    }
+
+    public int GetLanguageId(string language)
+        => _languageIds.TryGetValue(language, out var id) ? id : -1;
+}


### PR DESCRIPTION
Closes #34 

This pull request introduces a new language service to the codebase, adds support for mapping programming languages to Judge0 IDs, and expands the database context to support new entities related to problems, languages, and test cases. The main focus is on enabling language-to-Judge0 ID resolution and preparing the data model for problem and test case management.

**Key changes:**

### Language Service Implementation

* Added the `ILanguageService` interface to define a contract for resolving Judge0 IDs for languages (`Iteracode.Api/Abstractions/ILanguageService.cs`).
* Implemented the `LanguageService` class, which uses the application's database context to map enabled languages to their Judge0 IDs (`Iteracode.Api/Services/LanguageService.cs`).

### Data Model Enhancements

* Introduced the `LanguageJudge0Id` model to represent the mapping between a language, its Judge0 ID, and its enabled status (`Iteracode.Api/Models/LanguageJudge0Id.cs`).
* Updated `ApplicationDbContext` to include new `DbSet` properties for `Problem`, `ProblemLanguage`, `Testcase`, `ProblemTestcase`, `LanguageJudge0Id`, and `RunnerTemplate`, laying the groundwork for problem and test case management (`Iteracode.Api/Data/ApplicationDbContext.cs`).

### (Commented) Entity Relationship Configuration

* (Commented out) Added entity relationship configurations in `ApplicationDbContext` for composite keys, cascade deletes, and unique constraints for problem, testcase, and submission entities, indicating planned or in-progress data model relationships (`Iteracode.Api/Data/ApplicationDbContext.cs`).